### PR TITLE
Advertise IPv6 default route via RTR-ADVERT

### DIFF
--- a/terraform/vDS/segment-bastion/dhcp.conf.tmpl
+++ b/terraform/vDS/segment-bastion/dhcp.conf.tmpl
@@ -5,7 +5,7 @@ dhcp-range=z.z.${segment_number}.10,z.z.${segment_number}.99,1h
 dhcp-range=fd65:a1a8:60ad:271c::2,fd65:a1a8:60ad:271c::128,ra-names,slaac,64,3600
 enable-ra
 dhcp-option=option6:dns-server,[::]
-ra-param=*,0,0
+ra-param=*,30
 
 # direct DNS lookups to IBM DNS
 dhcp-option=6,y.y.y.y


### PR DESCRIPTION
This commit changes configuration of dnsmasq so that router advertises both prefixes and route via itself. Without this change only a route to the /64 subnet is advertised, but clients do not receive any default route. This is not desired because we need all the VMs in the subnet to contain a default route.

Routing table of a client before the change
```
::1 dev lo proto kernel metric 256 pref medium
fd65:a1a8:60ad:271c::/64 dev enp1s0 proto ra metric 100 pref medium
fe80::/64 dev enp1s0 proto kernel metric 1024 pref medium
```

and after

```
::1 dev lo proto kernel metric 256 pref medium
fd65:a1a8:60ad:271c::/64 dev enp1s0 proto ra metric 100 pref medium
fe80::/64 dev enp1s0 proto kernel metric 1024 pref medium
default via fe80::8fe2:ea40:9b01:9e3a dev enp1s0 proto ra metric 20100 pref medium
```